### PR TITLE
Bugfix: Fix ability to copy + paste

### DIFF
--- a/main-src/main.cjs
+++ b/main-src/main.cjs
@@ -186,7 +186,22 @@ function main() {
 app.enableSandbox()
 
 if (process.env.NODE_ENV !== 'dev') {
-  Menu.setApplicationMenu(null)
+  Menu.setApplicationMenu(Menu.buildFromTemplate([{
+    label: "StemRoller",
+    submenu: [
+        { label: "Undo", accelerator: "CmdOrCtrl+Z", role: "undo" },
+        { label: "Redo", accelerator: "Shift+CmdOrCtrl+Z", role: "redo" },
+        { type: "separator" },
+        { label: "Cut", accelerator: "CmdOrCtrl+X", role: "cut" },
+        { label: "Copy", accelerator: "CmdOrCtrl+C", role: "copy" },
+        { label: "Paste", accelerator: "CmdOrCtrl+V", role: "paste" },
+        { label: "Select All", accelerator: "CmdOrCtrl+A", role: "selectAll" },
+        { type: "separator" },
+        { label: "Hide", accelerator: "CmdOrCtrl+H", role: "hide" },
+        { label: "Quit", accelerator: "CmdOrCtrl+Q", role: "quit" },
+      ]
+    }]
+  ))
 }
 
 if (app.requestSingleInstanceLock()) {


### PR DESCRIPTION
This sets a proper, minimalistic application menu for production distributions and restores ability to copy + paste (as well as undo, redo, hide, quit, etc.).