### PR TITLE
Hotfix for ytdl-core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"tree-kill": "^1.2.2",
 				"xxhash-wasm": "^1.0.1",
 				"yt-search": "^2.10.3",
-				"ytdl-core": "^4.11.0"
+				"ytdl-core": "github:GreepTheSheep/node-ytdl-core"
 			},
 			"devDependencies": {
 				"@sveltejs/adapter-static": "^1.0.0-next.34",
@@ -7731,9 +7731,9 @@
 			}
 		},
 		"node_modules/ytdl-core": {
-			"version": "4.11.0",
-			"resolved": "https://registry.npmjs.org/ytdl-core/-/ytdl-core-4.11.0.tgz",
-			"integrity": "sha512-Q3hCLiUA9AOGQXzPvno14GN+HgF9wsO1ZBHlj0COTcyxjIyFpWvMfii0UC4/cAbVaIjEdbWB71GdcGuc4J1Lmw==",
+			"version": "0.0.0-development",
+			"resolved": "git+ssh://git@github.com/GreepTheSheep/node-ytdl-core.git#17a77cbe7f3a9670d6536fba7cb3f574c6da596a",
+			"license": "MIT",
 			"dependencies": {
 				"m3u8stream": "^0.8.6",
 				"miniget": "^4.2.2",
@@ -13441,9 +13441,8 @@
 			}
 		},
 		"ytdl-core": {
-			"version": "4.11.0",
-			"resolved": "https://registry.npmjs.org/ytdl-core/-/ytdl-core-4.11.0.tgz",
-			"integrity": "sha512-Q3hCLiUA9AOGQXzPvno14GN+HgF9wsO1ZBHlj0COTcyxjIyFpWvMfii0UC4/cAbVaIjEdbWB71GdcGuc4J1Lmw==",
+			"version": "git+ssh://git@github.com/GreepTheSheep/node-ytdl-core.git#17a77cbe7f3a9670d6536fba7cb3f574c6da596a",
+			"from": "ytdl-core@https://github.com/GreepTheSheep/node-ytdl-core",
 			"requires": {
 				"m3u8stream": "^0.8.6",
 				"miniget": "^4.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "stemroller",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "stemroller",
-			"version": "1.1.0",
+			"version": "1.1.1",
 			"license": "Unlicense",
 			"dependencies": {
 				"compare-versions": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "stemroller",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"private": true,
 	"type": "module",
 	"description": "Isolate vocals, drums, bass, and other instrumental stems from any song",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,6 @@
 		"tree-kill": "^1.2.2",
 		"xxhash-wasm": "^1.0.1",
 		"yt-search": "^2.10.3",
-		"ytdl-core": "^4.11.0"
+		"ytdl-core": "github:GreepTheSheep/node-ytdl-core"
 	}
 }


### PR DESCRIPTION
`ytdl-core` is broken at the moment, but https://github.com/GreepTheSheep/node-ytdl-core seems to work instead.