### PR TITLE
feat: show progress of the audio extraction

### DIFF
--- a/main-src/preload.cjs
+++ b/main-src/preload.cjs
@@ -1,5 +1,17 @@
 const { contextBridge, ipcRenderer } = require('electron')
 
+contextBridge.exposeInMainWorld('electron', {
+  onUpdateProgress: (callback) => {
+    ipcRenderer.on('progress-update', (event, progress) => {
+        callback(progress)
+    })
+
+    return () => {
+        ipcRenderer.removeAllListeners('progress-update')
+    }
+  }
+})
+
 contextBridge.exposeInMainWorld('computeLocalFileHash', (path) =>
   ipcRenderer.invoke('computeLocalFileHash', path)
 )
@@ -54,6 +66,7 @@ contextBridge.exposeInMainWorld(
     }
   }
 )
+
 ipcRenderer.on('videoStatusUpdate', (event, message) => {
   if (handlers.has('__global')) {
     for (const handler of handlers.get('__global').values()) {

--- a/renderer-src/components/ProcessQueue.svelte
+++ b/renderer-src/components/ProcessQueue.svelte
@@ -1,11 +1,24 @@
 <script>
+  import { onDestroy } from 'svelte'
   import ProcessQueueCard from '$components/ProcessQueueCard.svelte'
 
   export let items = null, onSplitClicked = null, onCancelClicked = null
+
+  let progress = 0, quantity = 0
+  const cleanupProgressListener = window.electron.onUpdateProgress((newProgress) => {
+      progress = newProgress
+      if (newProgress === 0) {
+        quantity++
+      }
+  })
+
+  onDestroy(() => {
+    cleanupProgressListener()
+  })
 </script>
 
 <div class="grow-0 shrink-0 overflow-x-auto overflow-y-hidden flex flex-row p-2 space-x-2 bg-slate-900 text-slate-100 border-solid border-t border-slate-700">
   {#each items as video}
-    <ProcessQueueCard {video} {onSplitClicked} {onCancelClicked} />
+    <ProcessQueueCard {video} {onSplitClicked} {onCancelClicked} {progress} {quantity} />
   {/each}
 </div>

--- a/renderer-src/components/ProcessQueueCard.svelte
+++ b/renderer-src/components/ProcessQueueCard.svelte
@@ -1,6 +1,5 @@
 <script>
   import { onDestroy } from 'svelte'
-  import { writable } from 'svelte/store'
   import Button from '$components/Button.svelte'
   import LoadingSpinnerIcon from '$icons/animated/LoadingSpinnerIcon.svelte'
   import CollectionIcon from '$icons/outline/CollectionIcon.svelte'
@@ -10,6 +9,7 @@
   import XCircleIcon from '$icons/solid/XCircleIcon.svelte'
 
   export let video = null, onSplitClicked = null, onCancelClicked = null
+  export let progress = null, quantity = null
   let hovered = false, cancelHovered = false
 
   function handleCancelClicked(event) {
@@ -45,21 +45,8 @@
     }
   }
 
-  // Set up listener for progress updates
-  let progress = writable(0)
-  let quantity = writable(0)
-  let newQuantity = 0
-  const cleanupProgress = window.electron.onUpdateProgress((newProgress) => {
-      progress.set(newProgress)
-      if (newProgress === 0) {
-        newQuantity++
-        quantity.set(newQuantity)
-      }
-  })
-
   onDestroy(() => {
     window.setVideoStatusUpdateHandler(video.videoId, 'ProcessQueueCard', null)
-    cleanupProgress()
   })
 </script>
 
@@ -96,7 +83,7 @@
             Remove
           {/if}
         {:else if status === 'processing'}
-          Processing {$quantity}/4 {$progress}%
+          Processing {quantity}/4 {progress}%
         {:else if status === 'downloading'}
           Downloading
         {:else if status === 'queued'}

--- a/renderer-src/components/ProcessQueueCard.svelte
+++ b/renderer-src/components/ProcessQueueCard.svelte
@@ -1,5 +1,6 @@
 <script>
   import { onDestroy } from 'svelte'
+  import { writable } from 'svelte/store'
   import Button from '$components/Button.svelte'
   import LoadingSpinnerIcon from '$icons/animated/LoadingSpinnerIcon.svelte'
   import CollectionIcon from '$icons/outline/CollectionIcon.svelte'
@@ -43,8 +44,22 @@
       onClick = undefined
     }
   }
+
+  // Set up listener for progress updates
+  let progress = writable(0)
+  let quantity = writable(0)
+  let newQuantity = 0
+  const cleanupProgress = window.electron.onUpdateProgress((newProgress) => {
+      progress.set(newProgress)
+      if (newProgress === 0) {
+        newQuantity++
+        quantity.set(newQuantity)
+      }
+  })
+
   onDestroy(() => {
     window.setVideoStatusUpdateHandler(video.videoId, 'ProcessQueueCard', null)
+    cleanupProgress()
   })
 </script>
 
@@ -81,7 +96,7 @@
             Remove
           {/if}
         {:else if status === 'processing'}
-          Processing
+          Processing {$quantity}/4 {$progress}%
         {:else if status === 'downloading'}
           Downloading
         {:else if status === 'queued'}

--- a/renderer-src/components/ResultCard.svelte
+++ b/renderer-src/components/ResultCard.svelte
@@ -1,6 +1,5 @@
 <script>
   import { onDestroy } from 'svelte'
-  import { writable } from 'svelte/store'
   import Button from '$components/Button.svelte'
   import AdjustmentsIcon from '$icons/solid/AdjustmentsIcon.svelte'
   import CollectionIcon from '$icons/solid/CollectionIcon.svelte'
@@ -9,6 +8,7 @@
   import LoadingSpinnerIcon from '$icons/animated/LoadingSpinnerIcon.svelte'
 
   export let video = null, onSplitClicked = null
+  export let progress = null, quantity = null
 
   async function handleOpenStemsClicked() {
     const result = await window.openStemsPath(video)
@@ -29,21 +29,8 @@
     })
   }
 
-  // Set up listener for progress updates
-  let progress = writable(0)
-  let quantity = writable(0)
-  let newQuantity = 0
-  const cleanupProgress = window.electron.onUpdateProgress((newProgress) => {
-      progress.set(newProgress)
-      if (newProgress === 0) {
-        newQuantity++
-        quantity.set(newQuantity)
-      }
-  })
-
   onDestroy(() => {
     window.setVideoStatusUpdateHandler(video.videoId, 'ResultCard', null)
-    cleanupProgress()
   })
 </script>
 
@@ -58,7 +45,7 @@
       <div class="whitespace-nowrap overflow-hidden text-ellipsis text-slate-400">{video.author.name}</div>
     </div>
     {#if status === 'processing'}
-      <Button Icon={LoadingSpinnerIcon} text="Processing {$quantity}/4 {$progress}%" disabled={true} />
+      <Button Icon={LoadingSpinnerIcon} text="Processing {quantity}/4 {progress}%" disabled={true} />
     {:else if status === 'downloading'}
       <Button Icon={LoadingSpinnerIcon} text="Downloading" disabled={true} />
     {:else if status === 'queued'}

--- a/renderer-src/components/ResultCard.svelte
+++ b/renderer-src/components/ResultCard.svelte
@@ -1,5 +1,6 @@
 <script>
   import { onDestroy } from 'svelte'
+  import { writable } from 'svelte/store'
   import Button from '$components/Button.svelte'
   import AdjustmentsIcon from '$icons/solid/AdjustmentsIcon.svelte'
   import CollectionIcon from '$icons/solid/CollectionIcon.svelte'
@@ -27,8 +28,22 @@
       path = message.path
     })
   }
+
+  // Set up listener for progress updates
+  let progress = writable(0)
+  let quantity = writable(0)
+  let newQuantity = 0
+  const cleanupProgress = window.electron.onUpdateProgress((newProgress) => {
+      progress.set(newProgress)
+      if (newProgress === 0) {
+        newQuantity++
+        quantity.set(newQuantity)
+      }
+  })
+
   onDestroy(() => {
     window.setVideoStatusUpdateHandler(video.videoId, 'ResultCard', null)
+    cleanupProgress()
   })
 </script>
 
@@ -43,7 +58,7 @@
       <div class="whitespace-nowrap overflow-hidden text-ellipsis text-slate-400">{video.author.name}</div>
     </div>
     {#if status === 'processing'}
-      <Button Icon={LoadingSpinnerIcon} text="Processing" disabled={true} />
+      <Button Icon={LoadingSpinnerIcon} text="Processing {$quantity}/4 {$progress}%" disabled={true} />
     {:else if status === 'downloading'}
       <Button Icon={LoadingSpinnerIcon} text="Downloading" disabled={true} />
     {:else if status === 'queued'}

--- a/renderer-src/components/SearchAndResults.svelte
+++ b/renderer-src/components/SearchAndResults.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { onMount, onDestroy } from 'svelte'
   import debounce from 'lodash.debounce'
   import ArrowUpIcon from '$icons/outline/ArrowUpIcon.svelte'
   import SearchIcon from '$icons/outline/SearchIcon.svelte'
@@ -64,6 +65,21 @@
       dndFileExplorerName = 'Finder'
     }
   }
+
+  let progress = 0, quantity = 0
+  let cleanupProgressListener
+  onMount(() => {
+    cleanupProgressListener = window.electron.onUpdateProgress((newProgress) => {
+        progress = newProgress
+        if (newProgress === 0) {
+          quantity++
+        }
+    })
+  })
+
+  onDestroy(() => {
+    cleanupProgressListener && cleanupProgressListener()
+  })
 </script>
 
 <div class="grow shrink overflow-hidden flex flex-col bg-slate-900 text-slate-100">
@@ -82,7 +98,7 @@
   <div class="grow shrink overflow-x-hidden overflow-y-auto flex flex-col p-6 space-y-6">
     {#if videos && status === null}
       {#each videos as video}
-        <ResultCard {video} {onSplitClicked} />
+        <ResultCard {video} {onSplitClicked} {progress} {quantity} />
       {/each}
     {:else if status === 'error'}
       <p class="m-4 text-slate-400 text-center">An error occurred. Please make sure you&apos;re connected to the internet and try again.</p>


### PR DESCRIPTION
I decided to take a stab at https://github.com/stemrollerapp/stemroller/issues/8 also. This one proved to be a bit tougher. I can understand if there's a certain part of the code you want to refactor a bit, but figured this was a good enough starting point. Happy to talk through any changes you'd like to make.

I wasn't sure what looked better, just doing the processQueueCard or the ResultCard or both. So I did both.

I didn't include the instrumental as one of the total outputs in the progress output since it's not generated by demucs and ffmpeg does it super fast.

Screenshot included below:
<img width="798" alt="Screenshot 2023-08-19 at 4 21 06 AM" src="https://github.com/stemrollerapp/stemroller/assets/13012689/91ea22cc-558c-40d6-9e26-fbbf25ddaada">

