### PR TITLE
Bug Fixes:  Update windows dependencies and add undici breaking update workaround

### DIFF
--- a/download-third-party-apps.js
+++ b/download-third-party-apps.js
@@ -176,7 +176,7 @@ async function main() {
         `${winOrMac}-extra-files`,
         'ThirdPartyApps',
         'ffmpeg',
-        'ffmpeg-7.0-essentials_build'
+        'ffmpeg-7.0.1-essentials_build'
       )
     )
   } else if (process.platform === 'darwin') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "stemroller",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stemroller",
-      "version": "2.0.6",
+      "version": "2.0.7",
       "license": "Unlicense",
       "dependencies": {
-        "@distube/ytdl-core": "^4.13.3",
+        "@distube/ytdl-core": "^4.13.5",
         "compare-versions": "^4.1.3",
         "electron-fetch": "^1.7.4",
         "electron-serve": "^1.1.0",
@@ -66,19 +66,22 @@
       }
     },
     "node_modules/@distube/ytdl-core": {
-      "version": "4.13.3",
-      "resolved": "https://registry.npmjs.org/@distube/ytdl-core/-/ytdl-core-4.13.3.tgz",
-      "integrity": "sha512-WHVzp0NyUkmdxRkfU8tN7eRquL7bnia2U/EDNWVupCptRo7EToTdBKHwJrDFqvavbXsdqLG/kR1r+1LaPglrFQ==",
+      "version": "4.13.5",
+      "resolved": "https://registry.npmjs.org/@distube/ytdl-core/-/ytdl-core-4.13.5.tgz",
+      "integrity": "sha512-g+4UJIR/auAJbia7iB0aWvaJDbs22P53NySWa47b1NT4xMTDJYguxHFArPrvRkcJrb/AgKjv/XoSZGghpL0CJA==",
       "dependencies": {
-        "http-cookie-agent": "^5.0.4",
+        "http-cookie-agent": "^6.0.5",
         "m3u8stream": "^0.8.6",
         "miniget": "^4.2.3",
-        "sax": "^1.2.4",
-        "tough-cookie": "^4.1.3",
-        "undici": "^5.25.2"
+        "sax": "^1.4.1",
+        "tough-cookie": "^4.1.4",
+        "undici": "^6.19.2"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/distubejs/ytdl-core?sponsor"
       }
     },
     "node_modules/@electron/get": {
@@ -195,9 +198,9 @@
       }
     },
     "node_modules/@fastify/busboy": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
-      "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
       "engines": {
         "node": ">=14"
       }
@@ -4329,36 +4332,32 @@
       "dev": true
     },
     "node_modules/http-cookie-agent": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-5.0.4.tgz",
-      "integrity": "sha512-OtvikW69RvfyP6Lsequ0fN5R49S+8QcS9zwd58k6VSr6r57T8G29BkPdyrBcSwLq6ExLs9V+rBlfxu7gDstJag==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-6.0.5.tgz",
+      "integrity": "sha512-sfZ8fDgDP3B1YB+teqSnAK1aPgBu8reUUGxSsndP2XnYN6cM29EURXWXZqQQiaRdor3B4QjpkUNfv21syaO4DA==",
       "dependencies": {
-        "agent-base": "^7.1.0"
+        "agent-base": "^7.1.1"
       },
       "engines": {
-        "node": ">=14.18.0 <15.0.0 || >=16.0.0"
+        "node": ">=18.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/3846masa"
       },
       "peerDependencies": {
-        "deasync": "^0.1.26",
         "tough-cookie": "^4.0.0",
-        "undici": "^5.11.0"
+        "undici": "^5.11.0 || ^6.0.0"
       },
       "peerDependenciesMeta": {
-        "deasync": {
-          "optional": true
-        },
         "undici": {
           "optional": true
         }
       }
     },
     "node_modules/http-cookie-agent/node_modules/agent-base": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -6369,9 +6368,9 @@
       }
     },
     "node_modules/sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
     },
     "node_modules/semver": {
       "version": "6.3.0",
@@ -7013,9 +7012,9 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
-      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
       "dependencies": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
@@ -7139,9 +7138,9 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "5.25.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.25.4.tgz",
-      "integrity": "sha512-450yJxT29qKMf3aoudzFpIciqpx6Pji3hEWaXqXmanbXF58LTAGCKxcJjxMXWu3iG+Mudgo3ZUfDB6YDFd/dAw==",
+      "version": "5.28.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
+      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },
@@ -7501,16 +7500,16 @@
       }
     },
     "@distube/ytdl-core": {
-      "version": "4.13.3",
-      "resolved": "https://registry.npmjs.org/@distube/ytdl-core/-/ytdl-core-4.13.3.tgz",
-      "integrity": "sha512-WHVzp0NyUkmdxRkfU8tN7eRquL7bnia2U/EDNWVupCptRo7EToTdBKHwJrDFqvavbXsdqLG/kR1r+1LaPglrFQ==",
+      "version": "4.13.5",
+      "resolved": "https://registry.npmjs.org/@distube/ytdl-core/-/ytdl-core-4.13.5.tgz",
+      "integrity": "sha512-g+4UJIR/auAJbia7iB0aWvaJDbs22P53NySWa47b1NT4xMTDJYguxHFArPrvRkcJrb/AgKjv/XoSZGghpL0CJA==",
       "requires": {
-        "http-cookie-agent": "^5.0.4",
+        "http-cookie-agent": "^6.0.5",
         "m3u8stream": "^0.8.6",
         "miniget": "^4.2.3",
-        "sax": "^1.2.4",
-        "tough-cookie": "^4.1.3",
-        "undici": "^5.25.2"
+        "sax": "^1.4.1",
+        "tough-cookie": "^4.1.4",
+        "undici": "5.28.4"
       }
     },
     "@electron/get": {
@@ -7601,9 +7600,9 @@
       }
     },
     "@fastify/busboy": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
-      "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.10.4",
@@ -10696,17 +10695,17 @@
       "dev": true
     },
     "http-cookie-agent": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-5.0.4.tgz",
-      "integrity": "sha512-OtvikW69RvfyP6Lsequ0fN5R49S+8QcS9zwd58k6VSr6r57T8G29BkPdyrBcSwLq6ExLs9V+rBlfxu7gDstJag==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-6.0.5.tgz",
+      "integrity": "sha512-sfZ8fDgDP3B1YB+teqSnAK1aPgBu8reUUGxSsndP2XnYN6cM29EURXWXZqQQiaRdor3B4QjpkUNfv21syaO4DA==",
       "requires": {
-        "agent-base": "^7.1.0"
+        "agent-base": "^7.1.1"
       },
       "dependencies": {
         "agent-base": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-          "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+          "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
           "requires": {
             "debug": "^4.3.4"
           }
@@ -12181,9 +12180,9 @@
       }
     },
     "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
     },
     "semver": {
       "version": "6.3.0",
@@ -12652,9 +12651,9 @@
       }
     },
     "tough-cookie": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
-      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
       "requires": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
@@ -12752,9 +12751,9 @@
       "dev": true
     },
     "undici": {
-      "version": "5.25.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.25.4.tgz",
-      "integrity": "sha512-450yJxT29qKMf3aoudzFpIciqpx6Pji3hEWaXqXmanbXF58LTAGCKxcJjxMXWu3iG+Mudgo3ZUfDB6YDFd/dAw==",
+      "version": "5.28.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
+      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
       "requires": {
         "@fastify/busboy": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stemroller",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "private": true,
   "type": "module",
   "description": "Isolate vocals, drums, bass, and other instrumental stems from any song",
@@ -54,7 +54,7 @@
     "tailwindcss": "^3.1.4"
   },
   "dependencies": {
-    "@distube/ytdl-core": "^4.13.3",
+    "@distube/ytdl-core": "^4.13.5",
     "compare-versions": "^4.1.3",
     "electron-fetch": "^1.7.4",
     "electron-serve": "^1.1.0",
@@ -63,5 +63,8 @@
     "tree-kill": "^1.2.2",
     "xxhash-wasm": "^1.0.1",
     "yt-search": "^2.10.4"
+  },
+  "overrides": {
+    "undici": "5.28.4"
   }
 }


### PR DESCRIPTION
One of the issues going on right now is ytdl-core updated one of their dependencies and marked it as a patch version change when it was supposed to be major(breaking).

Someone mentioned a workaround here and as of right now, it IS a workaround.

https://github.com/nodejs/undici/discussions/3010#discussioncomment-9581353

I'm sure once they get that squared away, that workaround should be removed.

A second issue I ran into is when standing up my dev workspace, a different version of ffmpeg was downloaded than what was expected.

 I can split this into 2 PRs if needed, but at the very least wanted to go ahead and at least stand up something in case people wanted to continue using stemroller by building from source.