### PR TITLE
Make stuff work more easily on Linux/ROCm

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ npm i -D
 
 Install `ffmpeg` globally using your preferred package manager, and install `demucs` globally with `pip`.
 
+If you get "Couldn't find appropriate backend" errors, try installing `libsox-dev` instead.
+
 ## Run in Development Mode
 
 `npm run dev`

--- a/main-src/processQueue.cjs
+++ b/main-src/processQueue.cjs
@@ -61,10 +61,7 @@ const PATH_TO_FFMPEG = PATH_TO_THIRD_PARTY_APPS
 const DEMUCS_EXE_NAME = PATH_TO_THIRD_PARTY_APPS ? 'demucs-cxfreeze' : 'demucs'
 const FFMPEG_EXE_NAME = 'ffmpeg'
 const CHILD_PROCESS_ENV = {
-  CUDA_PATH: process.env.CUDA_PATH,
-  PATH: process.env.PATH,
-  TEMP: process.env.TEMP,
-  TMP: process.env.TMP,
+  ... process.env,
   LANG: null, // Will be set when ready to split, since we can only check system locale after `app` is ready
 }
 if (PATH_TO_THIRD_PARTY_APPS) {


### PR DESCRIPTION
With my relatively new AMD Radeon RX 7800 XT I need to set the following envvars for ROCm to work:

~~~~
export PYTORCH_HIP_ALLOC_CONF=expandable_segments:True
export HSA_OVERRIDE_GFX_VERSION=11.0.0
export HCC_AMDGPU_TARGET=gfx1101
~~~~

Instead of hardcoding this all, just pass the whole parent environment in, this is the default behaviour anyway for most "spawn" APIs.

Also `torchaudio` can't detect my ffmpeg 7, it seems to not support this yet. `libsox-dev` works as an alternative.

Now I can demux stems in 20 seconds compared to 10 minutes for Wine/CPU! :D