### PR TITLE
Fix bootstrap script ffmpeg extraction + stabilize Demucs stem filenames

### DIFF
--- a/main-src/processQueue.js
+++ b/main-src/processQueue.js
@@ -218,6 +218,12 @@ async function findDemucsOutputDir(basePath) {
       return path.join(basePath, entry.name)
     }
   }
+
+  const hasFilesInBasePath = entries.some((entry) => entry.isFile())
+  if (hasFilesInBasePath) {
+    return basePath
+  }
+
   throw new Error('Unable to find Demucs output directory')
 }
 
@@ -325,6 +331,7 @@ async function _processVideo(video, tmpDir) {
     `Splitting video "${video.videoId}"; ${jobCount} jobs using model "${demucsModelName}"...`
   )
   const demucsExeArgs = [mediaPath, '-n', demucsModelName, '-j', jobCount]
+  demucsExeArgs.push('--filename', '{stem}.{ext}')
   if (getPyTorchBackend() === 'cpu') {
     console.log('Running with "-d cpu" to force CPU instead of CUDA')
     demucsExeArgs.push('-d', 'cpu')


### PR DESCRIPTION
## Summary

Fixes two issues:
- Bootstrap failures during the Windows ffmpeg extraction step
- Split/download failures caused by problematic source filename patterns (e.g., whitespace before extension)

## Changes

**Updated `download-third-party-apps.js`:**
- Added a guard in `moveDirChildrenUpAndDeleteDir` to skip gracefully when the source directory does not exist.
- Replaced hardcoded ffmpeg folder name handling with dynamic discovery of extracted directory matching ffmpeg-* and *essentials_build.
- Added explicit error when no extracted ffmpeg directory is found after unzip.

**Updated `processQueue.js`:**
- Added explicit Demucs filename template: --filename {stem}.{ext} to normalize stem filenames and avoid inherited problematic naming patterns.
- Hardened Demucs output path resolution in `findDemucsOutputDir` so it also accepts files written directly in the base output directory (not only nested subdirectory layout).

## Testing

Tested only on Windows 11

- Cloned fresh repository and ran `npm run download-third-party-apps`, confirmed no failures 
- Confirmed problematic file names no longer cause failures
  - Tested with `test .wav` filename; fails on latest release, succeeds with these changes